### PR TITLE
chore: `$ref`で参照するPath Item Objectの名前を変更

### DIFF
--- a/swagger/public/openapi.yaml
+++ b/swagger/public/openapi.yaml
@@ -12,9 +12,9 @@ servers:
 
 paths:
   /users/{username}/subjects:
-    $ref: "./subjects/paths.yaml#/users-{username}-subjects"
+    $ref: "./subjects/paths.yaml#/paths/users-{username}-subjects"
   /users/{username}/subjects/{subjectId}:
-    $ref: "./subjects/paths.yaml#/users-{username}-subjects-{subjectId}"
+    $ref: "./subjects/paths.yaml#/paths/users-{username}-subjects-{subjectId}"
 
 components:
   schemas:

--- a/swagger/public/openapi.yaml
+++ b/swagger/public/openapi.yaml
@@ -12,9 +12,9 @@ servers:
 
 paths:
   /users/{username}/subjects:
-    $ref: "./subjects/paths.yaml#/subjects"
+    $ref: "./subjects/paths.yaml#/users-{username}-subjects"
   /users/{username}/subjects/{subjectId}:
-    $ref: "./subjects/paths.yaml#/subjects_{subjectId}"
+    $ref: "./subjects/paths.yaml#/users-{username}-subjects-{subjectId}"
 
 components:
   schemas:

--- a/swagger/public/subjects/paths.yaml
+++ b/swagger/public/subjects/paths.yaml
@@ -1,4 +1,4 @@
-subjects:
+users-{username}-subjects:
   get:
     summary: ユーザーに紐づく教材の一覧を取得
     operationId: listUserSubjects
@@ -57,7 +57,7 @@ subjects:
             schema:
               $ref: "./schemas.yaml#/Subject"
 
-subjects_{subjectId}:
+users-{username}-subjects-{subjectId}:
   get:
     summary: ユーザーに紐づく教材の詳細を取得
     operationId: getUserSubject

--- a/swagger/public/subjects/paths.yaml
+++ b/swagger/public/subjects/paths.yaml
@@ -1,138 +1,139 @@
-users-{username}-subjects:
-  get:
-    summary: ユーザーに紐づく教材の一覧を取得
-    operationId: listUserSubjects
-    tags:
-      - subjects
-    parameters:
-      - name: username
-        in: path
+paths:
+  users-{username}-subjects:
+    get:
+      summary: ユーザーに紐づく教材の一覧を取得
+      operationId: listUserSubjects
+      tags:
+        - subjects
+      parameters:
+        - name: username
+          in: path
+          required: true
+          description: ユーザーネーム
+          schema:
+            type: string
+      responses:
+        "200":
+          description: ユーザーに紐づく教材の一覧
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "./schemas.yaml#/Subject"
+    post:
+      summary: ユーザーに紐づく教材を作成
+      operationId: createUserSubject
+      tags:
+        - subjects
+      parameters:
+        - name: username
+          in: path
+          required: true
+          description: ユーザーネーム
+          schema:
+            type: string
+      requestBody:
+        description: ユーザーに紐づく教材の情報
         required: true
-        description: ユーザーネーム
-        schema:
-          type: string
-    responses:
-      "200":
-        description: ユーザーに紐づく教材の一覧
         content:
           application/json:
             schema:
-              type: array
-              items:
+              type: object
+              properties:
+                username:
+                  type: string
+                name:
+                  type: string
+                description:
+                  type: string
+              required:
+                - username
+                - name
+      responses:
+        "201":
+          description: ユーザーに紐づく教材の作成
+          content:
+            application/json:
+              schema:
                 $ref: "./schemas.yaml#/Subject"
-  post:
-    summary: ユーザーに紐づく教材を作成
-    operationId: createUserSubject
-    tags:
-      - subjects
-    parameters:
-      - name: username
-        in: path
-        required: true
-        description: ユーザーネーム
-        schema:
-          type: string
-    requestBody:
-      description: ユーザーに紐づく教材の情報
-      required: true
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              username:
-                type: string
-              name:
-                type: string
-              description:
-                type: string
-            required:
-              - username
-              - name
-    responses:
-      "201":
-        description: ユーザーに紐づく教材の作成
-        content:
-          application/json:
-            schema:
-              $ref: "./schemas.yaml#/Subject"
 
-users-{username}-subjects-{subjectId}:
-  get:
-    summary: ユーザーに紐づく教材の詳細を取得
-    operationId: getUserSubject
-    tags:
-      - subjects
-    parameters:
-      - name: username
-        in: path
-        required: true
-        description: ユーザーネーム
-        schema:
-          type: string
-      - name: subjectId
-        in: path
-        required: true
-        description: 教材のID
-        schema:
-          type: string
-    responses:
-      "200":
-        description: ユーザーに紐づく教材の詳細
-        content:
-          application/json:
-            schema:
-              $ref: "./schemas.yaml#/Subject"
-  put:
-    summary: ユーザーに紐づく教材の詳細を更新
-    operationId: updateUserSubject
-    tags:
-      - subjects
-    parameters:
-      - name: username
-        in: path
-        required: true
-        description: ユーザーネーム
-        schema:
-          type: string
-      - name: subjectId
-        in: path
-        required: true
-        description: 教材のID
-        schema:
-          type: string
-    requestBody:
-      description: ユーザーに紐づく教材の情報
-      required: true
-      content:
-        application/json:
+  users-{username}-subjects-{subjectId}:
+    get:
+      summary: ユーザーに紐づく教材の詳細を取得
+      operationId: getUserSubject
+      tags:
+        - subjects
+      parameters:
+        - name: username
+          in: path
+          required: true
+          description: ユーザーネーム
           schema:
-            $ref: "./schemas.yaml#/Subject"
-    responses:
-      "200":
-        description: ユーザーに紐づく教材の更新
+            type: string
+        - name: subjectId
+          in: path
+          required: true
+          description: 教材のID
+          schema:
+            type: string
+      responses:
+        "200":
+          description: ユーザーに紐づく教材の詳細
+          content:
+            application/json:
+              schema:
+                $ref: "./schemas.yaml#/Subject"
+    put:
+      summary: ユーザーに紐づく教材の詳細を更新
+      operationId: updateUserSubject
+      tags:
+        - subjects
+      parameters:
+        - name: username
+          in: path
+          required: true
+          description: ユーザーネーム
+          schema:
+            type: string
+        - name: subjectId
+          in: path
+          required: true
+          description: 教材のID
+          schema:
+            type: string
+      requestBody:
+        description: ユーザーに紐づく教材の情報
+        required: true
         content:
           application/json:
             schema:
               $ref: "./schemas.yaml#/Subject"
-  delete:
-    summary: ユーザーに紐づく教材を削除
-    operationId: deleteUserSubject
-    tags:
-      - subjects
-    parameters:
-      - name: username
-        in: path
-        required: true
-        description: ユーザーネーム
-        schema:
-          type: string
-      - name: subjectId
-        in: path
-        required: true
-        description: 教材のID
-        schema:
-          type: string
-    responses:
-      "204":
-        description: ユーザーに紐づく教材の削除
+      responses:
+        "200":
+          description: ユーザーに紐づく教材の更新
+          content:
+            application/json:
+              schema:
+                $ref: "./schemas.yaml#/Subject"
+    delete:
+      summary: ユーザーに紐づく教材を削除
+      operationId: deleteUserSubject
+      tags:
+        - subjects
+      parameters:
+        - name: username
+          in: path
+          required: true
+          description: ユーザーネーム
+          schema:
+            type: string
+        - name: subjectId
+          in: path
+          required: true
+          description: 教材のID
+          schema:
+            type: string
+      responses:
+        "204":
+          description: ユーザーに紐づく教材の削除


### PR DESCRIPTION
resolve: #

## 概要
- `$ref`で参照されるPath Item Objectの名前を変更
  - Swagger UIで表示される内容には関係ない
- `$ref`で参照されるいくつかのPath Item Objectを、Paths Objectとしてまとめた

## 特にレビューしてほしいポイント
2つ目の変更で差分が見にくくなってます。1つ目のコミットのみに注目すると差分が見やすいと思います。
新しく付けた名前について気になるところがあったら教えて下さい！

## 備考
